### PR TITLE
Enforce fund/holding reservation at order admission

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ Start Kafka, PostgreSQL, Redis, Prometheus and Grafana:
 docker compose up -d
 ```
 
+### Database schema
+
+The app runs with `spring.jpa.hibernate.ddl-auto=validate`, so the schema must exist before
+boot. After provisioning the database, apply the reservation columns once:
+
+```bash
+psql "$DATABASE_URL" -f src/main/resources/db/reservation.sql
+```
+
 ### Running the application
 
 ```bash

--- a/docs/design/order-reservation.md
+++ b/docs/design/order-reservation.md
@@ -1,0 +1,179 @@
+# Design Doc: Fund & Holding Reservation (Admission-Time Invariant Enforcement)
+
+**Status:** Implemented (branch `feature/order-reservation`)
+**Date:** 2026-05-29
+**Scope:** Order placement → outbox → Kafka → execution pipeline
+
+---
+
+## 1. Context & Problem
+
+Order placement is asynchronous: `OrderService.publishOrder` persists a `PENDING`
+order plus an outbox row and returns `202 Accepted`; the order is later executed by
+`OrderExecutionService` off a Kafka topic.
+
+Before this change, **affordability was checked only at execution**, guarded by
+pessimistic row locks on `users` and `holdings`. Admission accepted every order
+unconditionally. Consequences:
+
+- **Over-commit.** A user with $100 could submit 50 BUY orders for $100 each. All 50
+  were accepted and acknowledged; 49 then failed at settlement. The write side
+  acknowledged commands it could never honor.
+- **Silent, futile failure.** On execution error the code set `status = "FAILED"` and
+  rethrew inside the same `@Transactional` method — so the `FAILED` write was rolled
+  back by its own rethrow. The order stayed `PENDING`, and there was no terminal,
+  client-visible rejection state.
+
+The underlying principle: **invariants must be enforced at the command-acceptance
+boundary, and every command must reach a terminal state (filled or rejected).**
+
+## 2. Goals / Non-Goals
+
+**Goals**
+- Reject un-affordable orders synchronously at admission (HTTP `422`), before they enter
+  the pipeline.
+- Guarantee balance and holdings can never go negative, even with many concurrent
+  in-flight orders for the same account.
+- Give failed orders a committed, client-visible `REJECTED` terminal state and never leak
+  or double-charge reserved resources.
+
+**Non-Goals**
+- Full dead-letter-queue / poison-message handling for the Kafka consumer (tracked
+  separately — see §9).
+- Limit orders, partial fills, or price-tolerance semantics. Orders remain `MARKET`.
+- Exposing reserved/available balance in read APIs (optional follow-up).
+
+## 3. Key Concepts
+
+- **Available balance** = `balance − reserved`. Cash spendable by *new* BUYs.
+- **Available quantity** = `quantity − reservedQuantity`. Units sellable by *new* SELLs.
+- **Reserve** (admission): move resources into escrow so concurrent orders see them as
+  unavailable.
+- **Settle** (fill): consume the reservation — debit actual cost / decrement units.
+- **Release** (rejection): return the reservation untouched.
+
+## 4. Data Model
+
+| Table | New column | Type | Meaning |
+|-------|-----------|------|---------|
+| `users` | `reserved` | `NUMERIC NOT NULL DEFAULT 0` | cash escrowed across pending BUYs |
+| `holdings` | `reserved_quantity` | `NUMERIC NOT NULL DEFAULT 0` | units escrowed across pending SELLs |
+| `orders` | `reserved_amount` | `NUMERIC` (null for SELL) | cash reserved for this BUY, enabling exact settle/release |
+
+`reserved_amount` is stored per-order so settlement/release frees *exactly* what was
+reserved, regardless of price drift.
+
+## 5. Design
+
+### 5.1 Admission — `OrderService.publishOrder` (inside existing `@Transactional`)
+
+After the idempotency check:
+
+- **BUY:** lock the user row (`findByIdWithLock`); compute
+  `cost = getPrice(ticker).price() × quantity`. If `balance − reserved < cost` →
+  throw `InsufficientFundsException`. Else `reserved += cost` and stamp
+  `order.reservedAmount = cost`.
+- **SELL:** lock the holding (`findByUserIdAndTicker`, `PESSIMISTIC_WRITE`). If absent or
+  `quantity − reservedQuantity < qty` → throw `InsufficientHoldingsException`. Else
+  `reservedQuantity += qty`.
+
+The order, outbox `UserTransaction`, and outbox-pending event are then written exactly as
+before. Row locks make concurrent admissions serialize, so the available-balance check is
+race-free.
+
+### 5.2 Settlement — `OrderExecutionService`
+
+Execution now runs the success path inside an explicit `TransactionTemplate` (matching the
+pattern already used in `OutboxPoller`) rather than a method-level `@Transactional`, so the
+commit/rollback boundary is unambiguous when a failure must be reacted to.
+
+- **BUY fill:** `UserService.settleBuy(userId, actualCost, reservedAmount)` debits the
+  actual cost and frees the reserved amount atomically under lock. If price rose past the
+  reservation and `balance − actualCost < 0`, it throws — the backstop.
+- **SELL fill:** decrement both `quantity` and `reservedQuantity` by the sold amount; credit
+  proceeds. The holding is deleted only when *both* reach zero.
+
+### 5.3 Failure handling
+
+```
+executeOrder:
+  doExecute() in TransactionTemplate   ← settlement; rolls back on any throw
+  ├─ InsufficientFunds/Holdings (business rejection):
+  │     rejectAndRelease() in a SEPARATE committed tx:
+  │       release reservation + set status = REJECTED
+  │     swallow  → Kafka offset advances (terminal)
+  └─ any other exception (transient, e.g. price feed down):
+        reservation left intact, order left PENDING
+        rethrow → Kafka redelivers → retry settles cleanly
+```
+
+The committed reject/release is the crux: it survives the rolled-back settlement
+transaction, so a rejected order's escrow is always returned and its terminal state
+persists. Distinguishing business rejection (terminal) from transient failure (retry)
+prevents both infinite poison loops and double-release on redelivery.
+
+### 5.4 API
+
+New `InsufficientFundsException` / `InsufficientHoldingsException` are mapped to HTTP
+`422 Unprocessable Entity` (RFC 7807 `ProblemDetail`) by a new `@RestControllerAdvice`
+(`ApiExceptionHandler`). Successful placement still returns `202 Accepted`.
+
+## 6. Concurrency & Correctness
+
+- All balance/holding mutations occur under `PESSIMISTIC_WRITE` locks, so read-modify-write
+  on `reserved` / `reservedQuantity` is serialized per account/holding.
+- Idempotency is unchanged: the dedupe key is recorded **only on successful fill**, so a
+  rejected order is never marked done, and a redelivered transient failure re-executes.
+- Reservation invariants: `0 ≤ reserved`, `0 ≤ reservedQuantity ≤ quantity` hold because
+  every reserve is matched by exactly one settle or one release.
+
+## 7. Alternatives Considered
+
+- **Compute available balance on the fly** (`balance − SUM(pending BUY costs)`) instead of a
+  stored `reserved` column. Rejected: extra query per admission, racier, and inconsistent
+  with the existing locked-row mutation style.
+- **Reserve with a price buffer** (e.g. `cost × 1.02`) to absorb upward drift. Rejected for
+  now in favor of the simpler reserve-at-current-price + negative-balance backstop; a buffer
+  can be layered on later if rejection-at-settlement proves common.
+- **Introduce Flyway** for the schema change. Deferred: the project currently has no
+  migration framework, so a checked-in SQL script matches existing conventions with the
+  least new surface.
+
+## 8. Schema Migration & Rollout
+
+The app runs with `spring.jpa.hibernate.ddl-auto=validate`, so the columns must exist before
+boot. Apply once before deploying:
+
+```bash
+psql "$DATABASE_URL" -f src/main/resources/db/reservation.sql
+```
+
+The script uses `ADD COLUMN IF NOT EXISTS ... DEFAULT 0`, which backfills existing rows and
+is safe to re-run. Roll forward only (no destructive changes); rollback = redeploy the prior
+build (the unused columns are harmless).
+
+## 9. Testing
+
+- **`OrderServiceTest`** (Mockito): BUY/SELL reserve correctly; reject when
+  `available < required`; duplicate key is a no-op (no double reserve); `reservedAmount` is
+  stamped on BUY and null on SELL.
+- **`OrderExecutionServiceTest`** (Mockito, real `TransactionTemplate` over a stub manager):
+  BUY fill settles + frees the exact reservation; business rejection releases + marks
+  `REJECTED` and does **not** record idempotency; SELL fill decrements reserved quantity;
+  transient failure rethrows and keeps the reservation.
+
+Run: `./mvnw test -Dtest=OrderServiceTest,OrderExecutionServiceTest` (9 tests, no infra).
+
+> Integration tests (`@SpringBootTest`) require live Postgres/Kafka/Redis **and**
+> `reservation.sql` applied; an end-to-end "two $100 BUYs → `202` then `422`" case belongs
+> there. Note `OrderControllerIntegrationTest` was already inconsistent (asserts `200` vs the
+> controller's `202`) prior to this change.
+
+## 10. Future Work
+
+- **Dead-letter queue / retry policy** for the consumer: cap retries on transient failures
+  and route true poison messages to `order.DLT` instead of relying on default redelivery.
+- Expose `availableBalance = balance − reserved` (and available quantity) in read APIs.
+- Optional reservation buffer for MARKET BUYs to reduce settlement-time rejections.
+- Reaper for reservations whose orders never execute (today the outbox reaper retries
+  indefinitely, which holds the reservation — acceptable but unbounded).

--- a/src/main/java/com/example/tradingsimulator/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/example/tradingsimulator/exception/ApiExceptionHandler.java
@@ -1,0 +1,15 @@
+package com.example.tradingsimulator.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler({InsufficientFundsException.class, InsufficientHoldingsException.class})
+    public ProblemDetail handleReservationRejection(RuntimeException ex) {
+        return ProblemDetail.forStatusAndDetail(HttpStatus.UNPROCESSABLE_ENTITY, ex.getMessage());
+    }
+}

--- a/src/main/java/com/example/tradingsimulator/exception/InsufficientFundsException.java
+++ b/src/main/java/com/example/tradingsimulator/exception/InsufficientFundsException.java
@@ -1,0 +1,7 @@
+package com.example.tradingsimulator.exception;
+
+public class InsufficientFundsException extends RuntimeException {
+    public InsufficientFundsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/tradingsimulator/exception/InsufficientHoldingsException.java
+++ b/src/main/java/com/example/tradingsimulator/exception/InsufficientHoldingsException.java
@@ -1,0 +1,7 @@
+package com.example.tradingsimulator.exception;
+
+public class InsufficientHoldingsException extends RuntimeException {
+    public InsufficientHoldingsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/tradingsimulator/model/Holding.java
+++ b/src/main/java/com/example/tradingsimulator/model/Holding.java
@@ -3,6 +3,7 @@ package com.example.tradingsimulator.model;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.math.BigDecimal;
 
@@ -23,6 +24,10 @@ public class Holding {
     private String ticker;
 
     private BigDecimal quantity;
+
+    @ColumnDefault("0")
+    @Column(nullable = false)
+    private BigDecimal reservedQuantity = BigDecimal.ZERO;
 
     public Holding() {
     }

--- a/src/main/java/com/example/tradingsimulator/model/Order.java
+++ b/src/main/java/com/example/tradingsimulator/model/Order.java
@@ -25,6 +25,8 @@ public class Order {
 
     private BigDecimal totalCost;
 
+    private BigDecimal reservedAmount;
+
     @Enumerated(EnumType.STRING)
     private OrderType orderType;
 

--- a/src/main/java/com/example/tradingsimulator/model/User.java
+++ b/src/main/java/com/example/tradingsimulator/model/User.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.math.BigDecimal;
 
@@ -49,6 +50,11 @@ public class User {
 
 
     private BigDecimal balance;
+
+    @Builder.Default
+    @ColumnDefault("0")
+    @Column(nullable = false)
+    private BigDecimal reserved = BigDecimal.ZERO;
 
     public User(String email, String username, String password, Role role )  {
         this.email = email;

--- a/src/main/java/com/example/tradingsimulator/service/OrderExecutionService.java
+++ b/src/main/java/com/example/tradingsimulator/service/OrderExecutionService.java
@@ -1,6 +1,8 @@
 package com.example.tradingsimulator.service;
 
 import com.example.tradingsimulator.dto.PriceDto;
+import com.example.tradingsimulator.exception.InsufficientFundsException;
+import com.example.tradingsimulator.exception.InsufficientHoldingsException;
 import com.example.tradingsimulator.kafka.OrderEvent;
 import com.example.tradingsimulator.model.Holding;
 import com.example.tradingsimulator.model.Order;
@@ -11,7 +13,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.math.BigDecimal;
 
@@ -24,6 +27,7 @@ public class OrderExecutionService {
     private final PriceTickerService priceService;
     private final UserService userService;
     private final IdempotencyService idempotencyService;
+    private final TransactionTemplate transactionTemplate;
 
     private final Counter buyCounter;
     private final Counter sellCounter;
@@ -36,12 +40,14 @@ public class OrderExecutionService {
                                  HoldingRepository holdingRepository,
                                  PriceTickerService priceService,
                                  IdempotencyService idempotencyService,
+                                 PlatformTransactionManager transactionManager,
                                  MeterRegistry registry) {
         this.orderRepository = orderRepository;
         this.userService = userService;
         this.holdingRepository = holdingRepository;
         this.priceService = priceService;
         this.idempotencyService = idempotencyService;
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
 
         this.buyCounter = Counter.builder("orders.executed").tag("type", "BUY").register(registry);
         this.sellCounter = Counter.builder("orders.executed").tag("type", "SELL").register(registry);
@@ -50,51 +56,62 @@ public class OrderExecutionService {
         this.executionTimer = Timer.builder("orders.execution.duration").register(registry);
     }
 
-    @Transactional
     public void executeOrder(OrderEvent event) {
         if (idempotencyService.findById(event.idempotencyKey()).isPresent()) {
             duplicateCounter.increment();
             return;
         }
 
-        Order order = orderRepository.findById(event.orderId()).orElse(null);
-        if (order == null) {
+        if (orderRepository.findById(event.orderId()).isEmpty()) {
             log.warn("Order {} not found, skipping stale event", event.orderId());
             return;
         }
 
-        executionTimer.record(() -> {
-            try {
-                PriceDto priceDto = priceService.getPrice(event.ticker());
-                BigDecimal totalCost = priceDto.price().multiply(event.quantity());
-
-                switch (event.orderType()) {
-                    case BUY -> {
-                        buyOrder(event, totalCost);
-                        buyCounter.increment();
-                    }
-                    case SELL -> {
-                        sellOrder(event, totalCost);
-                        sellCounter.increment();
-                    }
-                }
-
-                order.setTotalCost(totalCost);
-                order.setStatus("FILLED");
-                orderRepository.save(order);
-
-                idempotencyService.save(event.idempotencyKey(), event.orderId());
-            } catch (Exception e) {
-                failedCounter.increment();
-                order.setStatus("FAILED");
-                orderRepository.save(order);
-                throw new RuntimeException(e);
-            }
-        });
+        try {
+            // Settle in its own transaction so a failure rolls back cleanly, leaving the
+            // admission-time reservation intact for the reject/retry decision below.
+            executionTimer.record(() -> transactionTemplate.executeWithoutResult(s -> doExecute(event)));
+        } catch (InsufficientFundsException | InsufficientHoldingsException e) {
+            // Business rejection — terminal. Release the reservation, mark REJECTED in a
+            // committed transaction, and swallow so the Kafka offset advances.
+            failedCounter.increment();
+            log.warn("Order {} rejected: {}", event.orderId(), e.getMessage());
+            rejectAndRelease(event);
+        } catch (Exception e) {
+            // Transient/unknown failure — leave the reservation intact and rethrow so the
+            // message is retried. Nothing was committed, so retry re-executes cleanly.
+            failedCounter.increment();
+            log.error("Order {} failed transiently, will retry: {}", event.orderId(), e.getMessage());
+            throw e;
+        }
     }
 
-    private void buyOrder(OrderEvent event, BigDecimal totalCost) {
-        userService.decreaseBalance(event.userId(), totalCost);
+    private void doExecute(OrderEvent event) {
+        Order order = orderRepository.findById(event.orderId()).orElseThrow();
+
+        PriceDto priceDto = priceService.getPrice(event.ticker());
+        BigDecimal totalCost = priceDto.price().multiply(event.quantity());
+
+        switch (event.orderType()) {
+            case BUY -> {
+                buyOrder(event, order, totalCost);
+                buyCounter.increment();
+            }
+            case SELL -> {
+                sellOrder(event, totalCost);
+                sellCounter.increment();
+            }
+        }
+
+        order.setTotalCost(totalCost);
+        order.setStatus("FILLED");
+        orderRepository.save(order);
+
+        idempotencyService.save(event.idempotencyKey(), event.orderId());
+    }
+
+    private void buyOrder(OrderEvent event, Order order, BigDecimal totalCost) {
+        userService.settleBuy(event.userId(), totalCost, order.getReservedAmount());
 
         String username = userService.getUsername(event.userId());
         Holding holding = holdingRepository
@@ -112,16 +129,44 @@ public class OrderExecutionService {
                 .orElse(new Holding(event.userId(), username, event.ticker(), BigDecimal.ZERO));
 
         if (event.quantity().compareTo(holding.getQuantity()) > 0) {
-            throw new RuntimeException("Insufficient quantity!");
+            throw new InsufficientHoldingsException("Insufficient quantity!");
         }
 
         userService.increaseBalance(event.userId(), totalCost);
 
         holding.setQuantity(holding.getQuantity().subtract(event.quantity()));
-        if (holding.getQuantity().compareTo(BigDecimal.ZERO) == 0) {
+        holding.setReservedQuantity(holding.getReservedQuantity().subtract(event.quantity()));
+        if (holding.getQuantity().compareTo(BigDecimal.ZERO) == 0
+                && holding.getReservedQuantity().compareTo(BigDecimal.ZERO) == 0) {
             holdingRepository.delete(holding);
         } else {
             holdingRepository.save(holding);
         }
+    }
+
+    // Release the admission-time reservation and mark the order REJECTED. Runs in its own
+    // committed transaction so the outcome survives the rolled-back execution transaction.
+    private void rejectAndRelease(OrderEvent event) {
+        transactionTemplate.executeWithoutResult(s -> {
+            Order order = orderRepository.findById(event.orderId()).orElse(null);
+            if (order == null) return;
+
+            switch (event.orderType()) {
+                case BUY -> {
+                    if (order.getReservedAmount() != null) {
+                        userService.releaseReservation(event.userId(), order.getReservedAmount());
+                    }
+                }
+                case SELL -> holdingRepository
+                        .findByUserIdAndTicker(event.userId(), event.ticker())
+                        .ifPresent(h -> {
+                            h.setReservedQuantity(h.getReservedQuantity().subtract(event.quantity()));
+                            holdingRepository.save(h);
+                        });
+            }
+
+            order.setStatus("REJECTED");
+            orderRepository.save(order);
+        });
     }
 }

--- a/src/main/java/com/example/tradingsimulator/service/OrderService.java
+++ b/src/main/java/com/example/tradingsimulator/service/OrderService.java
@@ -1,11 +1,17 @@
 package com.example.tradingsimulator.service;
 
 import com.example.tradingsimulator.dto.OrderRequestDto;
+import com.example.tradingsimulator.exception.InsufficientFundsException;
+import com.example.tradingsimulator.exception.InsufficientHoldingsException;
 import com.example.tradingsimulator.kafka.OutboxPendingEvent;
+import com.example.tradingsimulator.model.Holding;
 import com.example.tradingsimulator.model.Idempotency;
 import com.example.tradingsimulator.model.Order;
+import com.example.tradingsimulator.model.User;
 import com.example.tradingsimulator.model.UserTransaction;
+import com.example.tradingsimulator.repository.HoldingRepository;
 import com.example.tradingsimulator.repository.OrderRepository;
+import com.example.tradingsimulator.repository.UserRepository;
 import com.example.tradingsimulator.repository.UserTransactionRepository;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -22,15 +28,24 @@ public class OrderService {
     private final UserTransactionRepository userTransactionRepository;
     private final IdempotencyService idempotencyService;
     private final ApplicationEventPublisher eventPublisher;
+    private final PriceTickerService priceService;
+    private final UserRepository userRepository;
+    private final HoldingRepository holdingRepository;
 
     public OrderService(OrderRepository orderRepository,
                         UserTransactionRepository userTransactionRepository,
                         IdempotencyService idempotencyService,
-                        ApplicationEventPublisher eventPublisher) {
+                        ApplicationEventPublisher eventPublisher,
+                        PriceTickerService priceService,
+                        UserRepository userRepository,
+                        HoldingRepository holdingRepository) {
         this.orderRepository = orderRepository;
         this.userTransactionRepository = userTransactionRepository;
         this.idempotencyService = idempotencyService;
         this.eventPublisher = eventPublisher;
+        this.priceService = priceService;
+        this.userRepository = userRepository;
+        this.holdingRepository = holdingRepository;
     }
 
     @Transactional
@@ -40,10 +55,13 @@ public class OrderService {
             return existing.get().getOrderId();
         }
 
+        BigDecimal reservedAmount = reserve(request);
+
         Order pending = new Order(
                 request.userId(), request.ticker(), request.quantity(),
                 BigDecimal.ZERO, request.orderType(), "MARKET", "PENDING", Instant.now()
         );
+        pending.setReservedAmount(reservedAmount);
         Order saved = orderRepository.save(pending);
 
         userTransactionRepository.save(new UserTransaction(
@@ -54,5 +72,52 @@ public class OrderService {
         eventPublisher.publishEvent(new OutboxPendingEvent());
 
         return saved.getId();
+    }
+
+    // Enforce the affordability invariant at admission: reserve cash for BUYs and holding
+    // quantity for SELLs so the system never accepts an order it cannot honor. Returns the
+    // cash reserved for the order (null for SELL, which reserves quantity instead).
+    private BigDecimal reserve(OrderRequestDto request) {
+        return switch (request.orderType()) {
+            case BUY -> reserveFunds(request);
+            case SELL -> {
+                reserveHolding(request);
+                yield null;
+            }
+        };
+    }
+
+    private BigDecimal reserveFunds(OrderRequestDto request) {
+        BigDecimal cost = priceService.getPrice(request.ticker()).price()
+                .multiply(request.quantity());
+
+        User user = userRepository.findByIdWithLock(request.userId())
+                .orElseThrow(() -> new IllegalArgumentException("User not found!"));
+
+        BigDecimal available = user.getBalance().subtract(user.getReserved());
+        if (available.compareTo(cost) < 0) {
+            throw new InsufficientFundsException(
+                    "Insufficient balance to place order: need " + cost + ", available " + available);
+        }
+
+        user.setReserved(user.getReserved().add(cost));
+        userRepository.save(user);
+        return cost;
+    }
+
+    private void reserveHolding(OrderRequestDto request) {
+        Holding holding = holdingRepository
+                .findByUserIdAndTicker(request.userId(), request.ticker())
+                .orElseThrow(() -> new InsufficientHoldingsException(
+                        "No holding for " + request.ticker() + " to sell"));
+
+        BigDecimal available = holding.getQuantity().subtract(holding.getReservedQuantity());
+        if (available.compareTo(request.quantity()) < 0) {
+            throw new InsufficientHoldingsException(
+                    "Insufficient quantity to sell: need " + request.quantity() + ", available " + available);
+        }
+
+        holding.setReservedQuantity(holding.getReservedQuantity().add(request.quantity()));
+        holdingRepository.save(holding);
     }
 }

--- a/src/main/java/com/example/tradingsimulator/service/UserService.java
+++ b/src/main/java/com/example/tradingsimulator/service/UserService.java
@@ -1,5 +1,6 @@
 package com.example.tradingsimulator.service;
 
+import com.example.tradingsimulator.exception.InsufficientFundsException;
 import com.example.tradingsimulator.model.User;
 import com.example.tradingsimulator.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,31 @@ public class UserService {
         }
 
         user.setBalance(newBalance);
+        userRepository.save(user);
+    }
+
+    // Settle a filled BUY: debit the actual cost and free the cash reserved at admission.
+    public void settleBuy(Long userId, BigDecimal actualCost, BigDecimal reservedAmount) {
+        User user = userRepository.findByIdWithLock(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found!"));
+
+        BigDecimal newBalance = user.getBalance().subtract(actualCost);
+        if (newBalance.compareTo(BigDecimal.ZERO) < 0) {
+            throw new InsufficientFundsException(
+                    "Insufficient balance at settlement: actual cost " + actualCost
+                            + " exceeds balance " + user.getBalance());
+        }
+
+        user.setBalance(newBalance);
+        user.setReserved(user.getReserved().subtract(reservedAmount));
+        userRepository.save(user);
+    }
+
+    // Release cash reserved at admission without debiting (order rejected/failed).
+    public void releaseReservation(Long userId, BigDecimal reservedAmount) {
+        User user = userRepository.findByIdWithLock(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found!"));
+        user.setReserved(user.getReserved().subtract(reservedAmount));
         userRepository.save(user);
     }
 

--- a/src/main/resources/db/reservation.sql
+++ b/src/main/resources/db/reservation.sql
@@ -1,0 +1,15 @@
+-- Reservation / escrow columns for admission-time invariant enforcement.
+-- Must be applied before deploying the feature/order-reservation branch:
+-- spring.jpa.hibernate.ddl-auto=validate will fail to boot otherwise.
+--
+-- Apply against the Postgres instance, e.g.:
+--   psql "$DATABASE_URL" -f src/main/resources/db/reservation.sql
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS reserved NUMERIC NOT NULL DEFAULT 0;
+
+ALTER TABLE holdings
+    ADD COLUMN IF NOT EXISTS reserved_quantity NUMERIC NOT NULL DEFAULT 0;
+
+ALTER TABLE orders
+    ADD COLUMN IF NOT EXISTS reserved_amount NUMERIC;

--- a/src/test/java/com/example/tradingsimulator/OrderExecutionServiceTest.java
+++ b/src/test/java/com/example/tradingsimulator/OrderExecutionServiceTest.java
@@ -1,0 +1,152 @@
+package com.example.tradingsimulator;
+
+import com.example.tradingsimulator.dto.PriceDto;
+import com.example.tradingsimulator.exception.InsufficientFundsException;
+import com.example.tradingsimulator.kafka.OrderEvent;
+import com.example.tradingsimulator.model.Holding;
+import com.example.tradingsimulator.model.Order;
+import com.example.tradingsimulator.model.OrderType;
+import com.example.tradingsimulator.repository.HoldingRepository;
+import com.example.tradingsimulator.repository.OrderRepository;
+import com.example.tradingsimulator.service.IdempotencyService;
+import com.example.tradingsimulator.service.OrderExecutionService;
+import com.example.tradingsimulator.service.PriceTickerService;
+import com.example.tradingsimulator.service.UserService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class OrderExecutionServiceTest {
+
+    @Mock private OrderRepository orderRepository;
+    @Mock private UserService userService;
+    @Mock private HoldingRepository holdingRepository;
+    @Mock private PriceTickerService priceService;
+    @Mock private IdempotencyService idempotencyService;
+    @Mock private PlatformTransactionManager txManager;
+
+    private OrderExecutionService service;
+
+    @BeforeEach
+    void setUp() {
+        // Real TransactionTemplate over a stub manager: getTransaction/commit/rollback are no-ops,
+        // so we exercise the same commit-vs-rollback branching the production code relies on.
+        when(txManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+        service = new OrderExecutionService(orderRepository, userService, holdingRepository,
+                priceService, idempotencyService, txManager, new SimpleMeterRegistry());
+    }
+
+    private OrderEvent event(OrderType type, BigDecimal qty) {
+        return new OrderEvent(1L, 2L, "AAPL", qty, type, "idem-1", Instant.now());
+    }
+
+    private Order order(OrderType type, BigDecimal reservedAmount) {
+        Order o = new Order();
+        o.setId(1L);
+        o.setUserId(2L);
+        o.setOrderType(type);
+        o.setReservedAmount(reservedAmount);
+        o.setStatus("PENDING");
+        return o;
+    }
+
+    @Test
+    void executeOrder_buyFill_settlesReservationDebitsActualCostAndCreditsHolding() {
+        Order order = order(OrderType.BUY, new BigDecimal("30"));
+        when(idempotencyService.findById("idem-1")).thenReturn(Optional.empty());
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(priceService.getPrice("AAPL")).thenReturn(new PriceDto("AAPL", new BigDecimal("10")));
+        when(userService.getUsername(2L)).thenReturn("bob");
+        when(holdingRepository.findByUserIdAndTicker(2L, "AAPL")).thenReturn(Optional.empty());
+
+        service.executeOrder(event(OrderType.BUY, new BigDecimal("3")));
+
+        // Settlement debits the actual cost (10*3) and frees exactly the reserved amount (30).
+        verify(userService).settleBuy(eq(2L), eq(new BigDecimal("30")), eq(new BigDecimal("30")));
+
+        ArgumentCaptor<Holding> holdingCaptor = ArgumentCaptor.forClass(Holding.class);
+        verify(holdingRepository).save(holdingCaptor.capture());
+        assertEquals(0, holdingCaptor.getValue().getQuantity().compareTo(new BigDecimal("3")));
+
+        assertEquals("FILLED", order.getStatus());
+        // Idempotency stamped only on success, so a redelivery is recognised as a duplicate.
+        verify(idempotencyService).save("idem-1", 1L);
+    }
+
+    @Test
+    void executeOrder_buy_whenSettlementRejected_releasesReservationAndMarksRejected() {
+        Order order = order(OrderType.BUY, new BigDecimal("30"));
+        when(idempotencyService.findById("idem-1")).thenReturn(Optional.empty());
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(priceService.getPrice("AAPL")).thenReturn(new PriceDto("AAPL", new BigDecimal("10")));
+        doThrow(new InsufficientFundsException("price rose past reservation"))
+                .when(userService).settleBuy(any(), any(), any());
+
+        // Business rejection is terminal — swallowed, not rethrown, so the Kafka offset advances.
+        service.executeOrder(event(OrderType.BUY, new BigDecimal("3")));
+
+        // The escrow must be returned exactly, never leaked.
+        verify(userService).releaseReservation(2L, new BigDecimal("30"));
+        assertEquals("REJECTED", order.getStatus());
+        // A rejected order never settles, so idempotency must NOT be recorded.
+        verify(idempotencyService, never()).save(any(), any());
+    }
+
+    @Test
+    void executeOrder_sellFill_decrementsReservedQuantityAndCreditsBalance() {
+        Order order = order(OrderType.SELL, null);
+        Holding holding = new Holding(2L, "bob", "AAPL", new BigDecimal("5"));
+        holding.setReservedQuantity(new BigDecimal("2"));
+        when(idempotencyService.findById("idem-1")).thenReturn(Optional.empty());
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        when(priceService.getPrice("AAPL")).thenReturn(new PriceDto("AAPL", new BigDecimal("10")));
+        when(userService.getUsername(2L)).thenReturn("bob");
+        when(holdingRepository.findByUserIdAndTicker(2L, "AAPL")).thenReturn(Optional.of(holding));
+
+        service.executeOrder(event(OrderType.SELL, new BigDecimal("2")));
+
+        verify(userService).increaseBalance(2L, new BigDecimal("20"));
+        // Both quantity and its reservation drop by the sold amount, keeping available-to-sell honest.
+        ArgumentCaptor<Holding> holdingCaptor = ArgumentCaptor.forClass(Holding.class);
+        verify(holdingRepository).save(holdingCaptor.capture());
+        assertEquals(0, holdingCaptor.getValue().getQuantity().compareTo(new BigDecimal("3")));
+        assertEquals(0, holdingCaptor.getValue().getReservedQuantity().compareTo(BigDecimal.ZERO));
+        assertEquals("FILLED", order.getStatus());
+    }
+
+    @Test
+    void executeOrder_transientFailure_rethrowsAndKeepsReservation() {
+        Order order = order(OrderType.BUY, new BigDecimal("30"));
+        when(idempotencyService.findById("idem-1")).thenReturn(Optional.empty());
+        when(orderRepository.findById(1L)).thenReturn(Optional.of(order));
+        // Non-business failure (e.g. price feed down) must NOT be treated as a rejection.
+        when(priceService.getPrice("AAPL")).thenThrow(new RuntimeException("price feed unavailable"));
+
+        assertThrows(RuntimeException.class,
+                () -> service.executeOrder(event(OrderType.BUY, new BigDecimal("3"))));
+
+        // Reservation stays intact and the order is not rejected, so a retry can settle cleanly.
+        verify(userService, never()).releaseReservation(any(), any());
+        verify(idempotencyService, never()).save(any(), any());
+    }
+}

--- a/src/test/java/com/example/tradingsimulator/OrderServiceTest.java
+++ b/src/test/java/com/example/tradingsimulator/OrderServiceTest.java
@@ -1,25 +1,39 @@
 package com.example.tradingsimulator;
 
 import com.example.tradingsimulator.dto.OrderRequestDto;
+import com.example.tradingsimulator.dto.PriceDto;
+import com.example.tradingsimulator.exception.InsufficientFundsException;
+import com.example.tradingsimulator.exception.InsufficientHoldingsException;
+import com.example.tradingsimulator.model.Holding;
 import com.example.tradingsimulator.model.Idempotency;
 import com.example.tradingsimulator.model.Order;
 import com.example.tradingsimulator.model.OrderType;
+import com.example.tradingsimulator.model.User;
+import com.example.tradingsimulator.repository.HoldingRepository;
 import com.example.tradingsimulator.repository.OrderRepository;
+import com.example.tradingsimulator.repository.UserRepository;
 import com.example.tradingsimulator.repository.UserTransactionRepository;
 import com.example.tradingsimulator.service.IdempotencyService;
 import com.example.tradingsimulator.service.OrderService;
+import com.example.tradingsimulator.service.PriceTickerService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.math.BigDecimal;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class OrderServiceTest {
@@ -27,45 +41,112 @@ public class OrderServiceTest {
     @Mock private OrderRepository orderRepository;
     @Mock private UserTransactionRepository userTransactionRepository;
     @Mock private IdempotencyService idempotencyService;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private PriceTickerService priceService;
+    @Mock private UserRepository userRepository;
+    @Mock private HoldingRepository holdingRepository;
 
     @InjectMocks private OrderService orderService;
 
-    @Test
-    void publishOrder_withNewIdempotencyKey_shouldSaveOrderAndReturnId() {
-        String idempotencyKey = "key-abc-123";
-        Long userId = 2L;
-        BigDecimal quantity = new BigDecimal("1.00");
+    private User user(BigDecimal balance, BigDecimal reserved) {
+        User u = new User();
+        u.setId(2L);
+        u.setBalance(balance);
+        u.setReserved(reserved);
+        return u;
+    }
 
-        when(idempotencyService.findById(idempotencyKey)).thenReturn(Optional.empty());
-
-        Order savedOrder = new Order();
-        savedOrder.setId(7L);
-        when(orderRepository.save(any(Order.class))).thenReturn(savedOrder);
-
-        Long result = orderService.publishOrder(
-                new OrderRequestDto(userId, "AAPL", quantity, OrderType.BUY), idempotencyKey
-        );
-
-        assertEquals(7L, result);
-        verify(orderRepository).save(any(Order.class));
-        verify(userTransactionRepository).save(any());
+    private Holding holding(BigDecimal quantity, BigDecimal reservedQuantity) {
+        Holding h = new Holding(2L, "bob", "AAPL", quantity);
+        h.setReservedQuantity(reservedQuantity);
+        return h;
     }
 
     @Test
-    void publishOrder_withDuplicateIdempotencyKey_shouldReturnExistingOrderIdWithoutProcessing() {
-        String idempotencyKey = "key-abc-123";
-        Long userId = 2L;
-
-        when(idempotencyService.findById(idempotencyKey))
-                .thenReturn(Optional.of(new Idempotency(idempotencyKey, 42L)));
+    void publishOrder_withDuplicateIdempotencyKey_shouldReturnExistingOrderIdWithoutReserving() {
+        when(idempotencyService.findById("key-abc-123"))
+                .thenReturn(Optional.of(new Idempotency("key-abc-123", 42L)));
 
         Long result = orderService.publishOrder(
-                new OrderRequestDto(userId, "AAPL", new BigDecimal("1.00"), OrderType.BUY),
-                idempotencyKey
-        );
+                new OrderRequestDto(2L, "AAPL", new BigDecimal("1.00"), OrderType.BUY), "key-abc-123");
 
+        // A duplicate must be a no-op so retries never double-reserve funds.
         assertEquals(42L, result);
         verify(orderRepository, never()).save(any());
         verify(userTransactionRepository, never()).save(any());
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void publishOrder_buy_shouldReserveFundsAndStampReservedAmountOnOrder() {
+        when(idempotencyService.findById("k1")).thenReturn(Optional.empty());
+        when(priceService.getPrice("AAPL")).thenReturn(new PriceDto("AAPL", new BigDecimal("10")));
+        User u = user(new BigDecimal("100"), BigDecimal.ZERO);
+        when(userRepository.findByIdWithLock(2L)).thenReturn(Optional.of(u));
+        Order saved = new Order();
+        saved.setId(7L);
+        when(orderRepository.save(any(Order.class))).thenReturn(saved);
+
+        Long result = orderService.publishOrder(
+                new OrderRequestDto(2L, "AAPL", new BigDecimal("3"), OrderType.BUY), "k1");
+
+        assertEquals(7L, result);
+        // Reservation = price * qty must be escrowed up-front so concurrent orders can't oversell balance.
+        assertEquals(0, u.getReserved().compareTo(new BigDecimal("30")));
+
+        ArgumentCaptor<Order> captor = ArgumentCaptor.forClass(Order.class);
+        verify(orderRepository).save(captor.capture());
+        // reservedAmount is what settlement later releases — it must equal the reserved cost.
+        assertEquals(0, captor.getValue().getReservedAmount().compareTo(new BigDecimal("30")));
+    }
+
+    @Test
+    void publishOrder_buy_whenAvailableLessThanCost_shouldRejectAndNotPersist() {
+        when(idempotencyService.findById("k2")).thenReturn(Optional.empty());
+        when(priceService.getPrice("AAPL")).thenReturn(new PriceDto("AAPL", new BigDecimal("10")));
+        // balance 100 but 95 already reserved by in-flight orders => only 5 available, order needs 30.
+        when(userRepository.findByIdWithLock(2L))
+                .thenReturn(Optional.of(user(new BigDecimal("100"), new BigDecimal("95"))));
+
+        assertThrows(InsufficientFundsException.class, () -> orderService.publishOrder(
+                new OrderRequestDto(2L, "AAPL", new BigDecimal("3"), OrderType.BUY), "k2"));
+
+        // Admission must refuse an order it cannot honor — nothing reaches the outbox.
+        verify(orderRepository, never()).save(any());
+        verify(userTransactionRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void publishOrder_sell_shouldReserveQuantityAndLeaveReservedAmountNull() {
+        when(idempotencyService.findById("k3")).thenReturn(Optional.empty());
+        Holding h = holding(new BigDecimal("5"), BigDecimal.ZERO);
+        when(holdingRepository.findByUserIdAndTicker(2L, "AAPL")).thenReturn(Optional.of(h));
+        Order saved = new Order();
+        saved.setId(9L);
+        when(orderRepository.save(any(Order.class))).thenReturn(saved);
+
+        orderService.publishOrder(
+                new OrderRequestDto(2L, "AAPL", new BigDecimal("2"), OrderType.SELL), "k3");
+
+        // Selling reserves units, not cash, so two sells can't dump more than is held.
+        assertEquals(0, h.getReservedQuantity().compareTo(new BigDecimal("2")));
+
+        ArgumentCaptor<Order> captor = ArgumentCaptor.forClass(Order.class);
+        verify(orderRepository).save(captor.capture());
+        assertNull(captor.getValue().getReservedAmount());
+    }
+
+    @Test
+    void publishOrder_sell_whenAvailableQuantityTooLow_shouldReject() {
+        when(idempotencyService.findById("k4")).thenReturn(Optional.empty());
+        // hold 5 but 4 already reserved by an in-flight sell => only 1 available, order wants 2.
+        when(holdingRepository.findByUserIdAndTicker(2L, "AAPL"))
+                .thenReturn(Optional.of(holding(new BigDecimal("5"), new BigDecimal("4"))));
+
+        assertThrows(InsufficientHoldingsException.class, () -> orderService.publishOrder(
+                new OrderRequestDto(2L, "AAPL", new BigDecimal("2"), OrderType.SELL), "k4"));
+
+        verify(orderRepository, never()).save(any());
     }
 }


### PR DESCRIPTION
## Summary

Moves the affordability invariant from async execution to the **command-acceptance boundary**, so the system never accepts an order it cannot honor. Previously every order was accepted unconditionally (a user with \$100 could submit 50 BUYs for \$100 each — all accepted, 49 later failed), and the failure path set `FAILED` then rethrew inside the same transaction, rolling back its own status write.

## What changed

- **Admission** (`OrderService.publishOrder`): under pessimistic lock, reserve cash for BUYs (`price × qty`) and holding quantity for SELLs. Reject with **422** when `balance − reserved` / `quantity − reservedQuantity` is insufficient. BUY orders stamp `reservedAmount` for exact settle/release.
- **Settlement** (`OrderExecutionService`): settle the reservation on fill; on **business rejection** release it and mark `REJECTED` in a *separate committed* transaction (survives the rolled-back execution); **transient** failures rethrow so Kafka retries cleanly. Uses `TransactionTemplate` like `OutboxPoller`.
- **Schema**: adds `users.reserved`, `holdings.reserved_quantity`, `orders.reserved_amount` via checked-in `src/main/resources/db/reservation.sql`. `ddl-auto` stays `validate`; README documents applying it before boot.
- **API**: new `InsufficientFundsException` / `InsufficientHoldingsException` → `422` via `ApiExceptionHandler` (`@RestControllerAdvice`).

## Testing

`./mvnw test -Dtest=OrderServiceTest,OrderExecutionServiceTest` → **9/9 pass** (pure Mockito, no infra). Covers admission reserve/reject, settlement, release-on-rejection, and transient rethrow.

⚠️ Integration tests (`@SpringBootTest`) were **not run** — they need live Postgres/Kafka/Redis **plus** `reservation.sql` applied. Note `OrderControllerIntegrationTest` was already inconsistent (asserts `200` vs the controller's `202`) independent of this change.

## Follow-ups (out of scope)

- Dead-letter queue / retry cap for poison messages.
- Expose `availableBalance = balance − reserved` in read APIs.

See `docs/design/order-reservation.md` for the full design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)